### PR TITLE
URL Cleanup

### DIFF
--- a/upload_external_contracts_to_artifactory.sh
+++ b/upload_external_contracts_to_artifactory.sh
@@ -10,7 +10,7 @@ APP_IP="$( ./whats_my_ip.sh )"
 APP_PORT="${APP_PORT:-9876}"
 ARTIFACTORY_PORT="${ARTIFACTORY_PORT:-8081}"
 APPLICATION_BASE_URL="http://${APP_IP}:${APP_PORT}"
-ARTIFACTORY_URL="http://admin:password@${APP_IP}:${ARTIFACTORY_PORT}/artifactory/libs-release-local"
+ARTIFACTORY_URL="https://admin:password@${APP_IP}:${ARTIFACTORY_PORT}/artifactory/libs-release-local"
 
 pushd spring-cloud-contract-nodejs-external-contracts
 echo "Running the build"


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://admin:password@ (UnknownHostException) with 1 occurrences migrated to:  
  https://admin:password@ ([https](https://admin:password@) result UnknownHostException).

# Ignored
These URLs were intentionally ignored.

* http://localhost:9876/api/books with 2 occurrences